### PR TITLE
Fixes a DOS attack vector

### DIFF
--- a/templating.md
+++ b/templating.md
@@ -120,7 +120,7 @@ If we would create our own templating system for every project, we would get no 
 
 ```ruby
 get '/:page.html' do |page|
-  erb page.to_sym
+  erb page
 end
 ```
 


### PR DESCRIPTION
Calling `#to_sym` on user supplied strings is a bad idea (and there's no reason why we should suggest doing so)
